### PR TITLE
fix: prevent bare '0' render when mints unreachable, surface backend …

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -12,6 +12,7 @@
   "lightning_tab": "⚡️ Lightning",
 
   "loading": "Loading",
+  "retrying": "Retrying…",
   "cancel": "Cancel",
   "paste": "Paste",
   "processing": "Processing…",
@@ -87,6 +88,11 @@
   "TG003_message": "TollGate could not connect to its relay. Contact the network administrator or try again later.",
   "TG004_label": "Pricing Error",
   "TG004_message": "Could not retrieve TollGate pricing information.",
+  "TG005_label": "Service Temporarily Unavailable",
+  "TG005_message": "TollGate is initializing. Please try again in a few moments.",
+
+  "no-reachable-mints_label": "Service Temporarily Unavailable",
+  "no-reachable-mints_message": "TollGate is initializing. No reachable mints detected. Service will auto-recover.",
 
   "CU001_label": "No access options available",
   "CU001_message": "Could not parse TollGate access options.",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -103,7 +103,7 @@ export const App = () => {
         <div className="tollgate-captive-portal-content">
           <div className="tollgate-captive-portal-content-container">
 
-            <div className="tollgate-captive-portal-tabs" aria-label={t('tab_aria_label')}>
+            <div className="tollgate-captive-portal-tabs" aria-label={t('tab_aria_label')} data-hidden={!loading && !!error}>
               <Tab type="cashu" method={method} setMethod={setMethod} />
               <Tab type="lightning" method={method} setMethod={setMethod} />
             </div>
@@ -111,8 +111,20 @@ export const App = () => {
             <div className="tollgate-captive-portal-view">
               {loading && <Loading />}
 
-              {!loading && error && <div className="tollgate-captive-portal-error">
+              {!loading && error && error.isBackendNotice && <div className="tollgate-captive-portal-error">
                 <Error label={error.label} code={error.code} message={error.message} />
+                {retrying && <div className="tollgate-captive-portal-retrying">
+                  <span className="spinner"></span>
+                  {t('retrying')}
+                </div>}
+              </div>}
+
+              {!loading && error && !error.isBackendNotice && <div className="tollgate-captive-portal-error">
+                <Error label={error.label} code={error.code} message={error.message} />
+                {retrying && <div className="tollgate-captive-portal-retrying">
+                  <span className="spinner"></span>
+                  {t('retrying')}
+                </div>}
               </div>}
 
               {/* show cashu or lightning method based on selection */}
@@ -238,7 +250,7 @@ export const AccessOptions = ({ pricingInfo, selectedMint, setSelectedMint }) =>
   const { t } = useTranslation();
   return <>
     {/* render a button for each available mint option */}
-    {pricingInfo.length && pricingInfo.map(mint => {
+    {pricingInfo.length > 0 && pricingInfo.map(mint => {
       if (!mint.price || !mint.url) return null;
       let mintAddressStripped = mint.url.replace('https://', '');
       mintAddressStripped = mintAddressStripped.replace('http://', '');

--- a/src/App.scss
+++ b/src/App.scss
@@ -47,6 +47,10 @@
   
   &-tabs {
     display: flex;
+
+    &[data-hidden=true] {
+      display: none;
+    }
   }
   
   &-tabs-tab {
@@ -217,6 +221,16 @@
     align-items: center;
     justify-content: center;
     flex-direction: column;
+  }
+
+  &-retrying {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: .6rem;
+    padding-top: .8rem;
+    font-size: var(--font-size-small);
+    color: var(--color-gray);
   }
 
   &-access-granted-label {

--- a/src/components/Cashu.jsx
+++ b/src/components/Cashu.jsx
@@ -133,7 +133,7 @@ export const Cashu = (props) => {
         {(success && !processing) && <AccessGranted allocation={`${allocation.value} ${allocation.unit}`} />}
 
         {/* tokeninput: input field and actions for entering or scanning a cashu token */}
-        {(!success && !processing && accessOptions.length) && <TokenInput token={token} setToken={setToken} scanning={scanning} setScanning={setScanning} setError={setError} />}
+        {(!success && !processing && accessOptions.length > 0) && <TokenInput token={token} setToken={setToken} scanning={scanning} setScanning={setScanning} setError={setError} />}
 
         {/* success: displays a message when a valid cashu token is detected, before purchase */}
         {(!success && !processing && tokenValue) && <Success
@@ -146,7 +146,7 @@ export const Cashu = (props) => {
         {error && <Error label={error.label} code={error.code} message={error.message} />}
 
         {/* accessoptions: lets the user select from available access/pricing options */}
-        {(!success && !processing && accessOptions.length) && <div className="tollgate-captive-portal-method-options">
+        {(!success && !processing && accessOptions.length > 0) && <div className="tollgate-captive-portal-method-options">
           <h5>{t('access_options')}</h5>
           <AccessOptions
             pricingInfo={accessOptions}

--- a/src/components/Lightning.jsx
+++ b/src/components/Lightning.jsx
@@ -141,7 +141,7 @@ export const Lightning = (props) => {
       {(success && !processing) && <AccessGranted allocation={`${allocation.value} ${allocation.unit}`} />}
 
       {/* unitinput: input field for entering the amount to pay, and selecting access option */}
-      {(!success && !processing && accessOptions.length && !invoiceData) && <UnitInput
+      {(!success && !processing && accessOptions.length > 0 && !invoiceData) && <UnitInput
         pricingInfo={accessOptions}
         selectedMint={selectedMint}
         unitAmount={unitAmount}
@@ -152,7 +152,7 @@ export const Lightning = (props) => {
       {error && <Error label={error.label} code={error.code} message={error.message} />}
 
       {/* accessoptions: lets the user select from available access/pricing options */}
-      {(!success && !processing && accessOptions.length && !invoiceData) && <div className="tollgate-captive-portal-method-options">
+      {(!success && !processing && accessOptions.length > 0 && !invoiceData) && <div className="tollgate-captive-portal-method-options">
         <h5>{t('access_options')}</h5>
         <AccessOptions
           pricingInfo={accessOptions}

--- a/src/helpers/tollgate.js
+++ b/src/helpers/tollgate.js
@@ -59,6 +59,24 @@ export const fetchTollgateData = async (i18n = (k, v) => k) => {
     // parse the tollgate event details from the response
     const detailsEvent = await detailsResponse.json();
 
+    // handle backend notice events (kind 21023) — e.g. degraded mode
+    if (detailsEvent.kind === 21023) {
+      const levelTag = detailsEvent.tags?.find(t => t[0] === "level");
+      const codeTag = detailsEvent.tags?.find(t => t[0] === "code");
+      const level = levelTag ? levelTag[1] : "error";
+      const code = codeTag ? codeTag[1] : "backend-notice";
+      const message = detailsEvent.content || i18n("TG005_message");
+
+      return {
+        status: 0,
+        code,
+        label: i18n(`${code}_label`, i18n("TG005_label")),
+        message,
+        isBackendNotice: true,
+        retryable: level === "warning",
+      };
+    }
+
     // fetch device mac address from the backend
     const whoamiResponse = await fetch(`${baseUrl}/whoami`);
 


### PR DESCRIPTION
…errors

React anti-pattern: array.length && JSX evaluates to 0 (rendered as text) when the array is empty. Changed all 5 occurrences to array.length > 0 &&.

Added kind 21023 (backend notice) detection in fetchTollgateData():
- Degraded mode notice now shown as user-facing error with backend message
- Retry spinner shown while auto-recovering
- Payment tabs hidden during degraded state
- Locale strings for no-reachable-mints and generic TG005 fallback