### PR TITLE
fix: null-guard deviceInfo to prevent SPA crash on whoami errors

### DIFF
--- a/src/components/DeviceInfo.jsx
+++ b/src/components/DeviceInfo.jsx
@@ -6,20 +6,30 @@ export const DeviceInfo = (props) => {
   const { tollgateDetails } = props;
   const { t: i18n } = useTranslation();
 
+  // defensively resolve deviceInfo. the /whoami endpoint may return an error or
+  // an empty/undefined payload, in which case tollgateDetails (or its deviceInfo)
+  // may be null/undefined. accessing .deviceInfo.type without these guards would
+  // throw a TypeError and crash the entire SPA.
+  const deviceInfo = tollgateDetails?.deviceInfo;
+
+  // if no device info is available (e.g. /whoami errored), render the footer
+  // without the device info line instead of crashing
+  if (!deviceInfo) {
+    return null;
+  }
+
   // set default values for device type and value
   let type = 'unkonw_type';
   let value = 'unknown_value';
 
-  // extract device type and value from tollgateDetails if available
-  if (tollgateDetails.deviceInfo) {
-    if (tollgateDetails.deviceInfo.type) {
-      if ('mac' === tollgateDetails.deviceInfo.type) {
-        type = i18n(`device_${tollgateDetails.deviceInfo.type}`);
-      }
+  // extract device type and value from deviceInfo using null-safe access
+  if (deviceInfo?.type) {
+    if ('mac' === deviceInfo.type) {
+      type = i18n(`device_${deviceInfo.type}`);
     }
-    if (tollgateDetails.deviceInfo.value) {
-      value = tollgateDetails.deviceInfo.value;
-    }
+  }
+  if (deviceInfo?.value) {
+    value = deviceInfo.value;
   }
 
   // render a paragraph with the device type and value

--- a/src/helpers/cashu.js
+++ b/src/helpers/cashu.js
@@ -154,21 +154,25 @@ export const submitToken = async (token, tollgateDetails, allocation, i18n) => {
       };
     }
 
+    // build the event tags. the device-identifier tag is only included when
+    // deviceInfo is available — /whoami may return an error or an empty payload,
+    // and accessing deviceInfo without a guard would throw a TypeError
+    const deviceInfo = tollgateDetails?.deviceInfo;
+    const tags = [
+      ["p", tollgatePubkey],
+      ...(deviceInfo
+        ? [["device-identifier", deviceInfo.type ?? "", deviceInfo.value ?? ""]]
+        : []),
+      ["payment", token],
+    ];
+
     // create the nostr event according to tip-01 spec
     const unsignedEvent = {
       kind: 21000,
       pubkey: pubkey,
       content: "",
       created_at: Math.floor(Date.now() / 1000),
-      tags: [
-        ["p", tollgatePubkey],
-        [
-          "device-identifier",
-          tollgateDetails.deviceInfo.type,
-          tollgateDetails.deviceInfo.value,
-        ],
-        ["payment", token],
-      ],
+      tags,
     };
 
     // calculate the event hash (id)


### PR DESCRIPTION
## Problem

DeviceInfo component and cashu token submission helper accessed tollgateDetails.deviceInfo without null-checking. When /whoami returns an error or deviceInfo is undefined, this crashes the SPA.

## Fix

DeviceInfo.jsx: early return null when deviceInfo is falsy, use optional chaining.
helpers/cashu.js: only include device-identifier tag when deviceInfo present.

Related to tollgate-module-basic-go PR #180. Related: PR #10.