### PR TITLE
fix(qr): hide camera scanner when mediaDevices API unavailable (HTTP captive portals)

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -115,6 +115,7 @@
   "QR003_message": "No QR code found in the selected image.",
   "QR004_label": "Camera error",
   "QR004_message": "Please make sure you have a camera and that this page has permission to use it.",
+  "qr_camera_unavailable": "Camera is not available in this browser (it requires a secure HTTPS connection). Upload a QR image instead, or paste your token.",
 
   "balance_tab": "💰 Balance",
   "balance_page_title": "Your Internet Balance",

--- a/src/components/BalancePage.jsx
+++ b/src/components/BalancePage.jsx
@@ -9,7 +9,7 @@ import { Error } from './Status';
 import { SuccessIcon, CancelIcon } from './Icon';
 
 // helpers
-import { requestScanQr } from '../helpers/qr-code';
+import { requestScanQr, hasCameraSupport } from '../helpers/qr-code';
 import { requestPaste } from '../helpers/clipboard';
 import { getAccessOptions, getStepSizeValues } from '../helpers/tollgate';
 import { getInternetBalance, formatBalance } from '../helpers/balance';
@@ -97,8 +97,10 @@ export const BalancePage = (props) => {
                     setError(paste);
                   }
                 }}>{t('paste')}</button>
-                {/* scan qr code */}
-                <button className="ghost cta small ellipsis" onClick={async () => {
+                {/* scan qr code — only shown when the camera API is usable
+                    (requires a secure context). On plain HTTP the paste
+                    button above remains the way to enter a token. */}
+                {hasCameraSupport() && <button className="ghost cta small ellipsis" onClick={async () => {
                   if (scanning) return;
                   setScanning(true);
                   const response = await requestScanQr(t);
@@ -110,7 +112,7 @@ export const BalancePage = (props) => {
                   setScanning(false);
                 }} disabled={scanning}>
                   {scanning ? t('scanning') : t('scan_qr')}
-                </button>
+                </button>}
               </>
             )}
           </div>

--- a/src/components/Cashu.jsx
+++ b/src/components/Cashu.jsx
@@ -10,7 +10,7 @@ import { Processing, AccessGranted, AccessOptions } from '../App'
 import { CancelIcon } from './Icon'
 
 // helpers
-import { requestScanQr } from '../helpers/qr-code';
+import { requestScanQr, hasCameraSupport } from '../helpers/qr-code';
 import { requestPaste } from '../helpers/clipboard';
 import { getAccessOptions, calculateAllocation } from '../helpers/tollgate';
 import { validateToken, submitToken } from '../helpers/cashu';
@@ -221,8 +221,10 @@ const TokenInput = ({ token, setToken, scanning, setScanning, setError }) => {
               setError(paste)
             }
           }}>{t('paste')}</button>
-          {/* scan qr code button */}
-          <button className="ghost cta small ellipsis" onClick={async () => {
+          {/* scan qr code button — only shown when the camera API is usable
+              (requires a secure context). On a plain-HTTP captive portal the
+              paste input above remains the primary way to enter a token. */}
+          {hasCameraSupport() && <button className="ghost cta small ellipsis" onClick={async () => {
             if (scanning) return;
             setScanning(true);
             const response = await requestScanQr(t);
@@ -237,7 +239,7 @@ const TokenInput = ({ token, setToken, scanning, setScanning, setError }) => {
             setScanning(false);
           }} disabled={scanning}>
             {scanning ? t('scanning') : t('scan_qr')}
-          </button>
+          </button>}
         </>}
       </div>
     </div>

--- a/src/helpers/qr-code.js
+++ b/src/helpers/qr-code.js
@@ -7,6 +7,24 @@ import QRCode from "qrcode-svg";
 // internal
 import { ImageIcon, FlipCameraIcon, CancelIcon } from "../components/Icon";
 
+// Detect whether the live camera API is usable in the current context.
+//
+// navigator.mediaDevices.getUserMedia() is only exposed in a *secure context*
+// (HTTPS or localhost). Captive portals serve over plain HTTP, so on
+// Firefox/Brave/Chrome the property is `undefined` and any attempt to scan
+// with the camera throws. Image-file upload, by contrast, has no such
+// restriction — so we use this check to decide whether to even offer the
+// camera scan button, and to fall back to upload-only mode inside the scanner.
+//
+// This is a pure feature detection (it never triggers a permission prompt).
+export function hasCameraSupport() {
+  return !!(
+    typeof navigator !== "undefined" &&
+    navigator.mediaDevices &&
+    typeof navigator.mediaDevices.getUserMedia === "function"
+  );
+}
+
 // request a qr code scan from the user, using camera or file upload
 export const requestScanQr = async (i18n) => {
   try {
@@ -184,29 +202,56 @@ export async function scanQr({ options = {} } = {}, i18n) {
       }
     };
 
+    // Capability check: getUserMedia requires a secure context (HTTPS or
+    // localhost). On a plain-HTTP captive portal, navigator.mediaDevices is
+    // undefined, so the camera cannot be used — but image-file upload still
+    // works. Degrade to upload-only mode rather than showing the misleading
+    // "make sure you have a camera" error.
+    if (!hasCameraSupport()) {
+      videoElem.style.display = "none";
+      flipButton.style.display = "none";
+      overlayInner.classList.add("error");
+      overlayInner.setAttribute("data-error", i18n("qr_camera_unavailable"));
+      return;
+    }
+
     // start camera and qr scanner
     await setupCameras();
-    qrScanner = new QrScanner(
-      videoElem,
-      (result) => {
-        // qr code found, stop scanner and cleanup
-        qrScanner.stop();
-        cleanup();
-        resolve({
-          status: 1,
-          value: result.data || result,
-        });
-      },
-      {
-        returnDetailedScanResult: true,
-        ...options,
-        preferredCamera: cameras[currentCameraIdx]?.id,
-      }
-    );
-    qrScanner.start().catch((err) => {
-      // failed to start camera or scanner
+    try {
+      qrScanner = new QrScanner(
+        videoElem,
+        (result) => {
+          // qr code found, stop scanner and cleanup
+          qrScanner.stop();
+          cleanup();
+          resolve({
+            status: 1,
+            value: result.data || result,
+          });
+        },
+        {
+          returnDetailedScanResult: true,
+          ...options,
+          preferredCamera: cameras[currentCameraIdx]?.id,
+        }
+      );
+    } catch (err) {
+      // some browsers throw synchronously when constructing QrScanner in a
+      // non-secure context — degrade to upload-only mode.
+      videoElem.style.display = "none";
+      flipButton.style.display = "none";
       overlayInner.classList.add("error");
-      overlayInner.setAttribute("data-error", i18n("QR004_message"));
+      overlayInner.setAttribute("data-error", i18n("qr_camera_unavailable"));
+      return;
+    }
+    qrScanner.start().catch((err) => {
+      // camera exists but could not start (permission denied, in use, etc.).
+      // Degrade to upload-only mode instead of blocking the overlay with a
+      // scary error — the upload button is still fully functional.
+      videoElem.style.display = "none";
+      flipButton.style.display = "none";
+      overlayInner.classList.add("error");
+      overlayInner.setAttribute("data-error", i18n("qr_camera_unavailable"));
     });
   });
 }


### PR DESCRIPTION
## Problem

Community member Busch21 reports that on Ubuntu with Brave/Firefox, the captive portal QR scanner immediately shows:

> "Please make sure you have a camera and that this page has permission to use it."

instead of requesting camera permission.

## Root cause

The qr-scanner library (nimiq) calls navigator.mediaDevices.getUserMedia(), which is only exposed in a secure context (HTTPS or localhost). Captive portals serve over plain HTTP, so on Firefox/Brave/Chrome navigator.mediaDevices is undefined and the library logs:

> "The camera stream is only accessible if the page is transferred via https."

The scanner then surfaces the misleading QR004 error instead of offering a usable fallback.

## Fix

This PR adds capability detection and graceful degradation:

1. hasCameraSupport() - pure feature detection in helpers/qr-code.js (checks navigator.mediaDevices && typeof getUserMedia === "function"). Never triggers a permission prompt.
2. Hide the "Scan QR" button in Cashu.jsx and BalancePage.jsx when the camera API is unavailable. The existing paste input remains the primary token-entry path.
3. Guard getUserMedia in scanQr() - when the API is missing, degrade to an upload-only overlay showing a new qr_camera_unavailable message instead of the scary QR004 error.
4. Wrap QrScanner construction in try/catch - some browsers throw synchronously in non-secure contexts.
5. Wrap qrScanner.start() failure to also degrade to upload-only mode (permission denied, camera in use, etc.).
6. New i18n string qr_camera_unavailable in en.json.

Image-file upload has no secure-context requirement, so the scanner overlay stays useful for uploading a QR screenshot even when the live camera is blocked.

## Why this matters

Even with v0.5 SSL/HTTPS management, many captive-portal detection contexts still load over http:// (cert-warning interception, detection URLs), so getUserMedia stays blocked. This makes the manual paste + image-upload path first-class instead of an afterthought.

## Testing

- [x] Code transforms cleanly (vite build: 139 modules transformed)
- [ ] Manual: Firefox over HTTP - scan button hidden, paste + upload work
- [ ] Manual: Brave over HTTP - scan button hidden, paste + upload work
- [ ] Manual: Chrome over HTTPS - scan button shown, camera works as before

Note on build: vite build fails in this environment on the generate-asset-manifest plugin (closeBundle scans a build/ dir that Vite 7 has not yet created). This failure is pre-existing on main (verified by stash + build on clean main - identical error) and unrelated to these changes. The maintainer build environment presumably handles this. Pre-built artifacts for module-basic-go packaging should be regenerated once the build env issue is resolved (tracked separately).

Refs: operator-experience-painpoints-plan.md (Pain Point 1)
