### PR TITLE
fix: TG002 status type — use 0 (falsy) instead of "error" (truthy)

### DIFF
--- a/src/helpers/tollgate.js
+++ b/src/helpers/tollgate.js
@@ -65,7 +65,7 @@ export const fetchTollgateData = async (i18n = (k, v) => k) => {
     if (!whoamiResponse.ok) {
       // if the request fails, return a specific error object
       return {
-        status: "error",
+        status: 0,
         code: "TG002",
         label: i18n("TG002_label"),
         message: i18n("TG002_message"),


### PR DESCRIPTION
## Problem

`fetchTollgateData()` returns `{ status: "error" }` when `/whoami` fails (TG002), but `App.jsx` checks `!response.status` to decide error vs success. The string `"error"` is **truthy**, so TG002 is treated as success — `tollgateDetails.value` is `undefined`, and the first component that accesses `.deviceInfo` or `.detailsEvent` crashes the entire SPA.

All other error paths already use `status: 0` (falsy):
- TG001 (details endpoint failure): `status: 0` ✅
- TG002 (whoami failure): `status: "error"` ❌ — **the only outlier**
- Catch blocks: `status: 0` ✅

## Fix

One line: `"error"` → `0`.

```diff
- status: "error",
+ status: 0,
```

## Verification (Playwright, production build)

Simulated the TG002 path: `/` returns valid details event, `/whoami` returns HTTP 500 empty body.

| Build | Crashes? | What user sees |
|---|---|---|
| Main branch (no fix) | **YES** — blank page | `TypeError: Cannot read properties of undefined (reading 'deviceInfo')` |
| Main + PR #12 null-guards | **YES — still crashes** | `TypeError: Cannot read properties of undefined (reading 'detailsEvent')` — different component, same root cause |
| Main + this fix | **NO** | Proper error page: "Failed to fetch device information #TG002" |

### Key finding: PR #12 alone does not fix the crash

PR #12's null-guards prevent the `DeviceInfo.jsx` crash, but the SPA **still goes blank** because `Cashu.jsx` accesses `tollgateDetails.detailsEvent` — and `tollgateDetails.value` is `undefined` in the TG002 error path. #12 moves the crash from one component to another. This one-line fix addresses the root cause so child components never render with undefined data.

## Relationship to other PRs

- **#12** (DeviceInfo null-guards) — still valuable as defensive hardening, but no longer load-bearing for this bug. Can merge independently.
- **tollgate-module-basic-go #180** (backend /whoami graceful degradation) — prevents the 500 in common cases, but this fix is needed regardless for any transient /whoami failure (network error, timeout, etc.)

No merge dependencies between the three PRs.