### PR TITLE
fix(clipboard): hide paste button when clipboard API unavailable

### DIFF
--- a/src/helpers/clipboard.js
+++ b/src/helpers/clipboard.js
@@ -1,3 +1,18 @@
+// Detect whether the clipboard read API is usable in the current context.
+//
+// navigator.clipboard.readText() is only available in a *secure context*
+// (HTTPS or localhost). Captive portals serve over plain HTTP, so on most
+// Android captive-portal WebViews navigator.clipboard is undefined and the
+// paste button silently fails with a confusing error. This pure feature
+// detection lets us hide the button instead of showing a broken one.
+export function hasClipboardSupport() {
+  return !!(
+    typeof navigator !== "undefined" &&
+    navigator.clipboard &&
+    typeof navigator.clipboard.readText === "function"
+  );
+}
+
 // request text from the user's clipboard
 export const requestPaste = async (i18n) => {
   try {


### PR DESCRIPTION
## Problem

The paste button on the payment input screen does not function in captive portal WebView environments. It calls `navigator.clipboard.readText()`, which is only available in a **secure context** (HTTPS or localhost). Captive portals serve over plain HTTP, so on most Android captive portal WebViews `navigator.clipboard` is `undefined` and the call throws a `TypeError`. The button appears broken with no useful feedback.

Reported in #228.

## Fix

Add `hasClipboardSupport()` — a pure feature detection that checks `navigator.clipboard` existence. Gate the paste button behind it in both `Cashu.jsx` and `BalancePage.jsx`, consistent with the QR scanner capability detection pattern from #15.

When clipboard is unavailable, the text input field still accepts manual paste (long-press → paste on Android, Ctrl+V on desktop) — so the user always has a working input path.

## Changes

- `src/helpers/clipboard.js` — new `hasClipboardSupport()` export
- `src/components/Cashu.jsx` — paste button wrapped in `{hasClipboardSupport() && ...}`
- `src/components/BalancePage.jsx` — same gate on the balance page paste button

## Testing

- [x] `vite build` succeeds (139 modules transformed)
- [ ] Manual: Android captive portal WebView — paste button hidden, manual paste works
- [ ] Manual: Desktop browser over HTTPS — paste button visible and functional

Note: this PR touches the same files as #15 (QR scanner). Merge order does not matter — either can be rebased onto the other.