### PR TITLE
feat(portal): session-expiry heartbeat with reconnect guidance

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -64,6 +64,11 @@
   "view_balance": "💰 View Balance",
   "balance_link_hint": "You can check your remaining internet balance at any time.",
 
+  "session_expired_title": "Session ended",
+  "session_expired_message": "Your internet access has expired. To get back online, disconnect from this Wi-Fi network and reconnect — that will reopen this portal so you can purchase more time.",
+  "session_expired_hint": "If reconnecting doesn't reopen this page automatically, open any website in your browser to trigger the portal.",
+  "session_expired_reconnect": "Refresh Portal",
+
   "TG001_label": "Failed to fetch TollGate details",
   "TG001_message": "Could not fetch TollGate details.",
   "TG002_label": "Failed to fetch device information",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,7 +9,7 @@ import Cashu from './components/Cashu.jsx'
 import Lightning from './components/Lightning.jsx'
 import { BalancePage } from './components/BalancePage.jsx'
 import { Error } from './components/Status.jsx';
-import { AccessGrantedIcon, RadioButtonIcon } from './components/Icon.jsx'
+import { AccessGrantedIcon, RadioButtonIcon, ErrorIcon } from './components/Icon.jsx'
 
 // helpers
 import { fetchTollgateData, getStepSizeValues, getTollgateBaseUrl } from './helpers/tollgate.js'
@@ -187,6 +187,7 @@ export const Processing = ({ label }) => {
 export const AccessGranted = ({ allocation }) => {
   const { t } = useTranslation();
   const [authCompleted, setAuthCompleted] = useState(false);
+  const [sessionExpired, setSessionExpired] = useState(false);
 
   // Auto-submit the auth form via fetch to complete captive portal authentication.
   // Using fetch instead of form.submit() intercepts the redirect to '/' so the
@@ -201,6 +202,51 @@ export const AccessGranted = ({ allocation }) => {
     }, 900);
     return () => clearTimeout(timer);
   }, []);
+
+  // Session-expiry heartbeat.
+  //
+  // NoDogSplash deauthenticates clients when their purchased time/data limit is
+  // reached. At that point the client loses internet access, but the portal page
+  // (if still open) gives no feedback — the user sees mysterious connection errors.
+  //
+  // We poll the /usage endpoint (always reachable on port 2121 even for
+  // unauthenticated clients). It returns "used/total" while the session is
+  // active, and "-1/-1" when the session has expired. After 2 consecutive
+  // failures we show a SessionExpired view telling the user to reconnect.
+  useEffect(() => {
+    if (!authCompleted) return;
+
+    let failures = 0;
+    let cancelled = false;
+
+    const heartbeat = setInterval(async () => {
+      if (cancelled) return;
+      try {
+        const resp = await fetch(`${getTollgateBaseUrl()}/usage`);
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const text = await resp.text();
+        if (text.includes('-1/-1')) {
+          throw new Error('session not found');
+        }
+        failures = 0;
+      } catch {
+        failures++;
+        if (failures >= 2) {
+          setSessionExpired(true);
+          clearInterval(heartbeat);
+        }
+      }
+    }, 30000); // check every 30s
+
+    return () => {
+      cancelled = true;
+      clearInterval(heartbeat);
+    };
+  }, [authCompleted]);
+
+  if (sessionExpired) {
+    return <SessionExpired />;
+  }
 
   // build the persistent portal balance URL from the gateway host
   const balanceUrl = `${getTollgateBaseUrl()}/portal`;
@@ -233,6 +279,24 @@ export const AccessGranted = ({ allocation }) => {
         {t('view_balance')}
       </a>
       <p className="small">{t('balance_link_hint')}</p>
+    </div>
+  </div>
+}
+
+// shown when the heartbeat detects the session has expired
+const SessionExpired = () => {
+  const { t } = useTranslation();
+  return <div className="tollgate-captive-portal-access-granted">
+    <div className="tollgate-captive-portal-access-granted-checkmark">
+      <ErrorIcon />
+    </div>
+    <div className="tollgate-captive-portal-access-granted-label">
+      <h2>{t('session_expired_title')}</h2>
+      <p>{t('session_expired_message')}</p>
+      <p className="small">{t('session_expired_hint')}</p>
+      <button className="cta" onClick={() => window.location.reload()}>
+        {t('session_expired_reconnect')}
+      </button>
     </div>
   </div>
 }


### PR DESCRIPTION
## Problem

When a purchased session expires (time/data limit reached), NoDogSplash deauthenticates the client and internet access silently stops. If the portal page is still open, the user sees no feedback — just mysterious connection errors with no indication that their session has ended.

Reported in #228.

## Fix

Add a heartbeat to `AccessGranted` that polls `/usage` every 30 seconds. The backend endpoint (port 2121) is always reachable even for deauthenticated clients (allowed via NoDogSplash `users_to_router`). It returns `"used/total"` while the session is active and `"-1/-1"` when expired. After 2 consecutive failures, the view switches to a `SessionExpired` screen that:

1. Explains the internet access has expired
2. Instructs the user to disconnect from the SSID and reconnect (which re-triggers the captive portal)
3. Offers a "Refresh Portal" button

The heartbeat only fires while the portal page is open. If the user closed it, their browser shows connection errors — reconnecting to the SSID re-triggers the captive portal as before. This is a best-effort improvement for the common case where the WebView stays open.

## Changes

- `src/App.jsx` — heartbeat effect in `AccessGranted`, new `SessionExpired` component
- `public/locales/en.json` — 4 new i18n strings

## Testing

- [x] `vite build` succeeds
- [ ] Manual: verify heartbeat fires after auth, detects session expiry, shows SessionExpired view

Refs: #228