### PR TITLE
feat: theme system — single config file drives all branding

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom/client';
 
 // internal
 import App from './App.jsx';
+import { ThemeProvider } from './theme/ThemeProvider';
 
 // helpers
 import './helpers/i18n';
@@ -15,6 +16,8 @@ import './index.scss';
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </React.StrictMode>
-); 
+);

--- a/src/theme/ThemeProvider.jsx
+++ b/src/theme/ThemeProvider.jsx
@@ -1,0 +1,68 @@
+import { createContext, useContext, useEffect, useMemo } from 'react';
+import defaultTheme from './defaultTheme';
+import userTheme from '../../theme.config';
+
+const ThemeContext = createContext(defaultTheme);
+
+export const useTheme = () => useContext(ThemeContext);
+
+function hexToRgb(hex) {
+  if (!hex) return null;
+  let match = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+  if (!match) {
+    match = /^#?([a-f\d])([a-f\d])([a-f\d])$/i.exec(hex);
+    if (match) {
+      match = [match[0], match[1] + match[1], match[2] + match[2], match[3] + match[3]];
+    }
+  }
+  if (!match) return null;
+  return `${parseInt(match[1], 16)}, ${parseInt(match[2], 16)}, ${parseInt(match[3], 16)}`;
+}
+
+function deepMerge(defaults, overrides) {
+  const result = { ...defaults };
+  for (const key of Object.keys(overrides)) {
+    if (
+      overrides[key] !== null &&
+      typeof overrides[key] === 'object' &&
+      !Array.isArray(overrides[key]) &&
+      defaults[key] &&
+      typeof defaults[key] === 'object' &&
+      !Array.isArray(defaults[key])
+    ) {
+      result[key] = { ...defaults[key], ...overrides[key] };
+    } else {
+      result[key] = overrides[key];
+    }
+  }
+  return result;
+}
+
+export function ThemeProvider({ children }) {
+  const theme = useMemo(() => deepMerge(defaultTheme, userTheme), []);
+
+  useEffect(() => {
+    const root = document.documentElement;
+    const { colors } = theme;
+
+    root.style.setProperty('--color-cta', colors.cta);
+    root.style.setProperty('--color-cta-transparent', colors.ctaTransparent);
+    root.style.setProperty('--color-black', colors.black);
+    root.style.setProperty('--color', colors.foreground);
+    root.style.setProperty('--color-brand-bg', colors.background);
+
+    const ctaRgb = hexToRgb(colors.cta);
+    if (ctaRgb) {
+      root.style.setProperty('--color-cta-hover', `rgba(${ctaRgb}, .25)`);
+      root.style.setProperty('--color-cta-hover-border', `rgba(${ctaRgb}, .5)`);
+    }
+
+    root.style.setProperty('--color-brand-bg', colors.background);
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={theme}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}

--- a/src/theme/defaultTheme.js
+++ b/src/theme/defaultTheme.js
@@ -1,0 +1,36 @@
+import tollgateLogo from '../assets/logo/TollGate_Logo-C-white.png';
+import tollgateIcon from '../assets/logo/TollGate_icon-White.png';
+
+export default {
+  brand: {
+    name: 'TollGate',
+    logo: tollgateLogo,
+    icon: tollgateIcon,
+    poweredByText: 'TollGate',
+    poweredByUrl: 'https://tollgate.me/',
+  },
+
+  colors: {
+    cta: '#FFB54C',
+    ctaTransparent: 'rgba(255, 181, 76, .8)',
+    background: '#080e1d',
+    black: '#000',
+    foreground: '#171D35',
+    particleLine: null,
+  },
+
+  pwa: {
+    enabled: true,
+    themeColor: '#FFB54C',
+    backgroundColor: '#080e1d',
+    icons: {
+      192: tollgateIcon,
+      512: tollgateIcon,
+    },
+  },
+
+  features: {
+    sizeSelector: true,
+    pwaModal: true,
+  },
+};

--- a/theme.config.js
+++ b/theme.config.js
@@ -1,0 +1,26 @@
+// Theme override file.
+//
+// Override any value from src/theme/defaultTheme.js to brand this captive
+// portal for your deployment. The ThemeProvider deep-merges this file over
+// the defaults.
+//
+// Example (net4sats.cash branding):
+//
+//   import net4satsLogo from './src/assets/net4sats-logo-colour.png';
+//
+//   export default {
+//     brand: {
+//       name: 'net4sats',
+//       logo: net4satsLogo,
+//       poweredByText: 'TollGate',
+//       poweredByUrl: 'https://tollgate.me/',
+//     },
+//     colors: {
+//       cta: '#f60',
+//       ctaTransparent: 'rgba(255, 102, 0, .8)',
+//     },
+//   };
+//
+// Leave as empty object to use TollGate defaults.
+
+export default {};


### PR DESCRIPTION
Enables white-label captive portal deployments. Drop in a logo + override a few colors in `theme.config.js` and the whole SPA re-brands.

## What

- Adds `src/theme/ThemeProvider.jsx` + `src/theme/defaultTheme.js` (TollGate defaults)
- Adds `theme.config.js` at repo root (empty override — no behaviour change unless customised)
- Wraps `<App />` in `<ThemeProvider>` in `src/index.jsx`

CSS custom properties (`--color-cta`, `--color-brand-bg`, etc.) are set at the document root, so existing SCSS using `var(--color-*)` inherits the configured theme automatically.

## Why

Operators deploying TollGate captive portals for their own brand currently have to fork the repo and edit SCSS. This PR lets them configure branding in one file without code changes.

## Build

```
✓ 141 modules transformed.
build/assets/index-*.js  488.59 kB │ gzip: 165.95 kB
✓ built in 1.84s
```

## Attribution

Ported from `Amperstrand/net4sats-captive-portal` (commit `b697d1c3`). Co-authored with @Amperstrand.

## Follow-ups (separate PRs)

- Migrate `src/App.jsx` Header/Footer to use `useTheme()` (currently hardcoded to TollGate logo)
- Add branding guide to README

Refs: b697d1c3