### PR TITLE
feat: OpenWrt ipk packaging + CI workflow

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -1,0 +1,70 @@
+name: Build Package
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+env:
+  PACKAGE_NAME: "tollgate-captive-portal"
+  NODE_VERSION: "22"
+
+jobs:
+  determine-versioning:
+    runs-on: ubuntu-latest
+    outputs:
+      package_version: ${{ steps.version.outputs.package_version }}
+    steps:
+      - uses: actions/checkout@v4
+      - id: version
+        run: |
+          SHORT_SHA=$(git rev-parse --short HEAD)
+          BASE_VERSION=$(jq -r .version package.json)
+          PACKAGE_VERSION="${BASE_VERSION}.${{ github.run_number }}.${SHORT_SHA}"
+          echo "package_version=${PACKAGE_VERSION}" >> $GITHUB_OUTPUT
+          echo "Version: ${PACKAGE_VERSION}"
+
+  build-spa:
+    runs-on: ubuntu-latest
+    needs: determine-versioning
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - run: npm install
+      - run: npm run build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: spa-dist
+          path: build/
+
+  package-ipk:
+    needs: [determine-versioning, build-spa]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        architecture:
+          - aarch64_cortex-a53
+          - aarch64_cortex-a72
+          - arm_cortex-a7
+          - mips_24kc
+          - mipsel_24kc
+          - x86_64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: spa-dist
+          path: build/
+      - name: Build ipk
+        run: |
+          chmod +x packaging/build-ipk.sh
+          packaging/build-ipk.sh \
+            "${{ matrix.architecture }}" \
+            "${{ needs.determine-versioning.outputs.package_version }}"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.PACKAGE_NAME }}_${{ needs.determine-versioning.outputs.package_version }}_${{ matrix.architecture }}.ipk
+          path: "*.ipk"

--- a/packaging/build-ipk.sh
+++ b/packaging/build-ipk.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -euo pipefail
+
+ARCH="${1:-aarch64_cortex-a53}"
+VERSION="${2:-$(jq -r .version package.json)}"
+PACKAGE_NAME="tollgate-captive-portal"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BUILD_DIR="$REPO_ROOT/build"
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+echo "=== Building $PACKAGE_NAME ipk ==="
+echo "  Architecture: $ARCH"
+echo "  Version:      $VERSION"
+echo "  Source:       $BUILD_DIR"
+
+if [ ! -f "$BUILD_DIR/splash.html" ]; then
+    echo "ERROR: Build output not found. Run 'npm run build' first."
+    exit 1
+fi
+
+CTRL_DIR="$WORK_DIR/control"
+DATA_DIR="$WORK_DIR/data"
+
+mkdir -p "$CTRL_DIR" "$DATA_DIR"
+
+# Install portal files to nodogsplash htdocs
+mkdir -p "$DATA_DIR/etc/nodogsplash/htdocs"
+cp -r "$BUILD_DIR/." "$DATA_DIR/etc/nodogsplash/htdocs/"
+
+cat > "$CTRL_DIR/control" << EOF
+Package: tollgate-captive-portal
+Version: ${VERSION}
+Architecture: ${ARCH}
+Maintainer: TollGate <dev@tollgate.me>
+License: GPL-3.0
+Depends: tollgate-wrt, nodogsplash
+Provides: tollgate-captive-portal-site
+Conflicts: tollgate-captive-portal
+Description: TollGate captive portal SPA
+ A branded captive portal skin for TollGate WiFi payment.
+ Provides the tollgate-captive-portal-site virtual package,
+ deploying the captive portal SPA to nodogsplash htdocs.
+ Pays with Cashu tokens or BTC Lightning via the TollGate backend.
+EOF
+
+cp "$SCRIPT_DIR/postinst" "$CTRL_DIR/postinst"
+cp "$SCRIPT_DIR/prerm" "$CTRL_DIR/prerm"
+chmod 755 "$CTRL_DIR/postinst" "$CTRL_DIR/prerm"
+
+cd "$WORK_DIR"
+tar -czf control.tar.gz -C "$CTRL_DIR" .
+tar -czf data.tar.gz -C "$DATA_DIR" .
+
+echo "2.0" > debian-binary
+
+OUTPUT="$REPO_ROOT/${PACKAGE_NAME}_${VERSION}_${ARCH}.ipk"
+# OpenWrt opkg expects gzip-compressed tarball, not ar archive
+tar -czf "$OUTPUT" ./debian-binary ./control.tar.gz ./data.tar.gz
+
+SIZE=$(du -h "$OUTPUT" | cut -f1)
+echo "=== Built: $OUTPUT ($SIZE) ==="

--- a/packaging/postinst
+++ b/packaging/postinst
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+echo "Restarting NoDogSplash with TollGate portal..."
+/etc/init.d/nodogsplash restart 2>/dev/null || true
+
+echo "TollGate captive portal installed."
+exit 0

--- a/packaging/prerm
+++ b/packaging/prerm
@@ -1,0 +1,4 @@
+#!/bin/sh
+echo "Removing TollGate captive portal, restoring default..."
+/etc/init.d/nodogsplash restart 2>/dev/null || true
+exit 0


### PR DESCRIPTION
Adds scripts and GitHub Actions workflow to build an OpenWrt `.ipk` package of the captive portal SPA. Enables router-native deployment via `opkg install` rather than manual scp.

## What

| File | Purpose |
|---|---|
| `packaging/build-ipk.sh` | Builds `.ipk` from `build/` output (architecture + version parameterised) |
| `packaging/postinst` | Restarts nodogsplash post-install |
| `packaging/prerm` | Cleanup hook pre-removal |
| `.github/workflows/build-package.yml` | CI: build SPA → assemble ipk → upload artifact |

## Package metadata

```
Package:    tollgate-captive-portal
Version:    <from package.json>.<run_number>.<short_sha>
Depends:    tollgate-wrt, nodogsplash
Provides:   tollgate-captive-portal-site
Conflicts:  tollgate-captive-portal
```

The package deploys built assets to `/etc/nodogsplash/htdocs/` so the captive portal SPA replaces the default nodogsplash splash page.

## Why

Currently operators have to scp the SPA manually (or build it on-router). This PR enables `opkg install tollgate-captive-portal_<version>_<arch>.ipk` for clean install/upgrade/remove lifecycle.

## Conflicts with PR #11

PR #11 (`feat/admin-spa-packaging`) also adds OpenWrt packaging via a different approach (apk + Makefile + rpcd plugin). Recommendation: **merge this PR's simpler .ipk approach first**, then let PR #11 add the admin SPA packaging on top once it's rebased and split.

## Attribution

Ported from `Amperstrand/net4sats-captive-portal` (commits `bb9dfeb5` + `c3df896b`); rebranded net4sats → TollGate for upstream.

Co-authored with @Amperstrand.

Refs: #11