### PR TITLE
feat: toast notification system

### DIFF
--- a/src/components/Toast.jsx
+++ b/src/components/Toast.jsx
@@ -1,0 +1,45 @@
+import { useToast } from './ToastContext';
+import './Toast.scss';
+
+const ICONS = {
+  info: (
+    <svg viewBox="0 0 20 20" fill="currentColor" width="18" height="18">
+      <path d="M10 0C4.48 0 0 4.48 0 10s4.48 10 10 10 10-4.48 10-10S15.52 0 10 0zm1 15H9v-2h2v2zm0-4H9V5h2v6z"/>
+    </svg>
+  ),
+  success: (
+    <svg viewBox="0 0 20 20" fill="currentColor" width="18" height="18">
+      <path d="M10 0C4.48 0 0 4.48 0 10s4.48 10 10 10 10-4.48 10-10S15.52 0 10 0zm-1 15l-5-5 1.41-1.41L9 12.17l7.59-7.59L18 6l-9 9z"/>
+    </svg>
+  ),
+  warning: (
+    <svg viewBox="0 0 20 20" fill="currentColor" width="18" height="18">
+      <path d="M1 17h18L10 1 1 17zm10-3H9v-2h2v2zm0-4H9V7h2v3z"/>
+    </svg>
+  ),
+};
+
+const ToastItem = ({ toast, onDismiss }) => {
+  return (
+    <div className={`toast toast--${toast.type}`} onClick={() => onDismiss(toast.id)}>
+      <span className="toast__icon">{ICONS[toast.type] || ICONS.info}</span>
+      <span className="toast__message">{toast.message}</span>
+    </div>
+  );
+};
+
+export const ToastContainer = () => {
+  const { toasts, removeToast } = useToast();
+
+  if (!toasts.length) return null;
+
+  return (
+    <div className="toast-container">
+      {toasts.map((toast) => (
+        <ToastItem key={toast.id} toast={toast} onDismiss={removeToast} />
+      ))}
+    </div>
+  );
+};
+
+export default ToastContainer;

--- a/src/components/Toast.scss
+++ b/src/components/Toast.scss
@@ -1,0 +1,86 @@
+.toast-container {
+  position: fixed;
+  bottom: 1.6rem;
+  right: 1.6rem;
+  display: flex;
+  flex-direction: column-reverse;
+  gap: .8rem;
+  z-index: 99999;
+  pointer-events: none;
+}
+
+.toast {
+  display: flex;
+  align-items: flex-start;
+  gap: .8rem;
+  max-width: 35rem;
+  padding: 1rem 1.4rem;
+  border-radius: var(--border-radius);
+  box-shadow: 0 .4rem 1.2rem rgba(0, 0, 0, 0.18);
+  backdrop-filter: blur(.6rem);
+  -webkit-backdrop-filter: blur(.6rem);
+  pointer-events: auto;
+  cursor: pointer;
+  animation: toast-slide-in .3s ease-out forwards;
+  font-size: var(--font-size-small);
+  line-height: 1.4;
+
+  &__icon {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    padding-top: .1rem;
+
+    svg {
+      width: 1.6rem;
+      height: 1.6rem;
+    }
+  }
+
+  &__message {
+    flex: 1;
+    word-break: break-word;
+  }
+
+  &--info {
+    background-color: rgba(59, 130, 246, 0.92);
+    color: #fff;
+
+    .toast__icon svg {
+      fill: #fff;
+    }
+  }
+
+  &--success {
+    background-color: rgba(74, 169, 34, 0.92);
+    color: #fff;
+
+    .toast__icon svg {
+      fill: #fff;
+    }
+  }
+
+  &--warning {
+    background-color: rgba(217, 142, 20, 0.92);
+    color: #fff;
+
+    .toast__icon svg {
+      fill: #fff;
+    }
+  }
+
+  &:hover {
+    opacity: .85;
+  }
+}
+
+@keyframes toast-slide-in {
+  from {
+    opacity: 0;
+    transform: translateX(100%);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}

--- a/src/components/ToastContext.jsx
+++ b/src/components/ToastContext.jsx
@@ -1,0 +1,40 @@
+import { createContext, useContext, useState, useCallback, useRef } from 'react';
+
+const ToastContext = createContext(null);
+
+let toastId = 0;
+
+export const ToastProvider = ({ children }) => {
+  const [toasts, setToasts] = useState([]);
+  const timersRef = useRef({});
+
+  const removeToast = useCallback((id) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+    if (timersRef.current[id]) {
+      clearTimeout(timersRef.current[id]);
+      delete timersRef.current[id];
+    }
+  }, []);
+
+  const addToast = useCallback((message, type = 'info') => {
+    const id = ++toastId;
+    setToasts((prev) => [...prev, { id, message, type }]);
+    timersRef.current[id] = setTimeout(() => removeToast(id), 4000);
+  }, [removeToast]);
+
+  return (
+    <ToastContext.Provider value={{ addToast, removeToast, toasts }}>
+      {children}
+    </ToastContext.Provider>
+  );
+};
+
+export const useToast = () => {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error('useToast must be used within a ToastProvider');
+  }
+  return context;
+};
+
+export default ToastContext;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -4,6 +4,8 @@ import ReactDOM from 'react-dom/client';
 
 // internal
 import App from './App.jsx';
+import { ToastProvider } from './components/ToastContext';
+import ToastContainer from './components/Toast';
 
 // helpers
 import './helpers/i18n';
@@ -15,6 +17,9 @@ import './index.scss';
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <ToastProvider>
+      <App />
+      <ToastContainer />
+    </ToastProvider>
   </React.StrictMode>
-); 
+);


### PR DESCRIPTION
Adds reusable toast notifications for user feedback (success, warnings, errors). Auto-dismisses after 4s, click-to-dismiss.

## What

| File | Purpose | Lines |
|---|---|---|
| `src/components/ToastContext.jsx` | Provider + `useToast()` hook (`addToast(message, type)`) | 40 |
| `src/components/Toast.jsx` | Container rendering active toasts | 45 |
| `src/components/Toast.scss` | Styles (info/success/warning variants) | 86 |
| `src/index.jsx` | Wire `<ToastProvider>` + `<ToastContainer>` | +4 lines |

## Usage

```jsx
import { useToast } from './components/ToastContext';

const { addToast } = useToast();
addToast('Payment successful', 'success');
addToast('Invalid token', 'warning');
addToast('Network error', 'info');
```

## Build

✅ `npm run build` exit 0.

## Note on index.jsx conflict

This PR modifies `src/index.jsx` to add `<ToastProvider>`. **PR #23** (theme system) also modifies `src/index.jsx` to add `<ThemeProvider>`. Whichever merges first, the other will need a trivial rebase to combine both wrappers:

```jsx
<ThemeProvider>
  <ToastProvider>
    <App />
    <ToastContainer />
  </ToastProvider>
</ThemeProvider>
```

## Attribution

Ported from `Amperstrand/net4sats-captive-portal` (commit `1e27ee8c`). Clean port — no branding changes needed.

Co-authored with @Amperstrand.