### PR TITLE
feat: demo mode — GitHub Pages deployment with mock data

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -1,0 +1,46 @@
+name: Deploy demo to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm ci
+      - run: npx vite build
+        env:
+          VITE_MOCK: "true"
+          VITE_BASE_PATH: /tollgate-captive-portal-site/
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: build
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import Cashu from './components/Cashu.jsx'
 import Lightning from './components/Lightning.jsx'
 import { BalancePage } from './components/BalancePage.jsx'
 import { Error } from './components/Status.jsx';
+import DemoBanner from './components/DemoBanner.jsx';
 import { AccessGrantedIcon, RadioButtonIcon, ErrorIcon } from './components/Icon.jsx'
 
 // helpers
@@ -96,6 +97,7 @@ export const App = () => {
   // main render
   return (
     <div id="tollgate-captive-portal" className="tollgate-captive-portal">
+      <DemoBanner />
       <Background />
 
       <div className="tollgate-captive-portal-interface">

--- a/src/components/DemoBanner.jsx
+++ b/src/components/DemoBanner.jsx
@@ -1,0 +1,14 @@
+import './DemoBanner.scss';
+
+export const DemoBanner = () => {
+  if (!import.meta.env.VITE_MOCK) return null;
+
+  return (
+    <div className="demo-banner">
+      <span className="demo-banner__dot" />
+      Demo Mode — using simulated data
+    </div>
+  );
+};
+
+export default DemoBanner;

--- a/src/components/DemoBanner.scss
+++ b/src/components/DemoBanner.scss
@@ -1,0 +1,37 @@
+.demo-banner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: .6rem;
+  background-color: rgba(255, 181, 76, 0.14);
+  border-bottom: .1rem solid rgba(255, 181, 76, 0.3);
+  color: var(--color-negative);
+  font-size: var(--font-size-xsmall);
+  font-weight: 600;
+  letter-spacing: .03em;
+  text-transform: uppercase;
+  z-index: 99998;
+  pointer-events: none;
+
+  &__dot {
+    width: .6rem;
+    height: .6rem;
+    border-radius: 50%;
+    background-color: #FFB54C;
+    animation: demo-pulse 2s ease-in-out infinite;
+  }
+}
+
+@keyframes demo-pulse {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: .4;
+  }
+}

--- a/src/helpers/tollgate.js
+++ b/src/helpers/tollgate.js
@@ -112,9 +112,10 @@ export const fetchTollgateData = async (i18n = (k, v) => k) => {
     // catch any unexpected errors
     console.error("error fetching tollgate data:", err);
 
-    // Development fallback: if backend is unreachable (network error),
-    // use mock data so the UI is testable without a real TollGate
-    if (import.meta.env?.DEV || window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1") {
+    // Development/demo fallback: if backend is unreachable (network error),
+    // use mock data so the UI is testable without a real TollGate.
+    // VITE_MOCK=true enables this in production builds (e.g. GitHub Pages demo).
+    if (import.meta.env?.DEV || import.meta.env?.VITE_MOCK || window.location.hostname === "localhost" || window.location.hostname === "127.0.0.1") {
       console.warn("Backend unreachable — using mock data for development");
       return {
         status: 1,


### PR DESCRIPTION
Adds a live demo at `https://opentollgate.github.io/tollgate-captive-portal-site/` — the SPA builds with mock data so it's viewable without a router backend.

## What

| File | Purpose |
|---|---|
| `src/components/DemoBanner.jsx` | Fixed-position banner showing 'Demo Mode — using simulated data'. Only renders when `VITE_MOCK=true`. |
| `src/components/DemoBanner.scss` | Pulsing dot + TollGate color scheme |
| `src/helpers/tollgate.js` | Extends the existing dev fallback to also trigger on `VITE_MOCK=true` (so production builds on GitHub Pages get mock data) |
| `src/App.jsx` | Renders `<DemoBanner />` at the top of the portal |
| `.github/workflows/deploy-demo.yml` | CI: builds with `VITE_MOCK=true` → deploys to GitHub Pages on every push to main |

## Why

1. **Marketing** — a live demo at `tollgate.me` or GitHub Pages lets people see the portal without hardware
2. **Testing** — QA can verify UI changes against a visible deployment
3. **Onboarding** — new contributors can immediately see what they're building

## Build verification

✅ `VITE_MOCK=true npm run build` exit 0. DemoBanner code present in bundle.

## Note on index.jsx / App.jsx conflicts

This PR modifies `src/App.jsx` (adds DemoBanner import + render). Other open PRs may also touch App.jsx — trivial rebase if needed.

## Attribution

Ported from `Amperstrand/net4sats-captive-portal` (commits `1e27ee8c` + `8aed75d8` + `8239a93e`). Rebranded `VITE_BASE_PATH` for upstream repo name.

Co-authored with @Amperstrand.